### PR TITLE
Fix getGlobalState

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,8 @@ export const createGlobalState = (initialState) => {
           } else {
             newValue = funcOrValue;
           }
-          this.setState({ value: newValue });
           stateItemValues[name] = newValue;
+          this.setState({ value: newValue });
         });
         this.state = { value: initialState[name], update: stateItemUpdaters[name] };
       }


### PR DESCRIPTION
Need to update `stateItemValues ` before calling `this.setState` as a re-render can lead to calling `getGlobalState` before `stateItemValues` is updated